### PR TITLE
Split feature context to run tests relevant to Drupal version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,14 @@ class FeatureContext extends DrupalContext {
 
 To debug tests from CLI:
 1. SSH into CLI container: `docker-compose -p behatsteps exec cli sh`
-2. `./xdebug.sh vendor/bin/behat path/to/file`
+2. `./xdebug.sh vendor/bin/behat -p d7 path/to/file`
+   
+   IMPORTANT: When running tests directly, always specify profile for the 
+   version of Drupal your are running:
+      ```
+      vendor/bin/behat -p d7
+      ```      
+      or
+      ```
+      vendor/bin/behat -p d8
+      ```

--- a/behat.yml
+++ b/behat.yml
@@ -7,12 +7,6 @@ default:
   suites:
     default:
       paths: [ %paths.base%/tests/behat/features ]
-      contexts:
-        - FeatureContext
-        - Drupal\DrupalExtension\Context\MinkContext
-        - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\MessageContext
-        - IntegratedExperts\BehatScreenshotExtension\Context\ScreenshotContext
 
   extensions:
     Behat\MinkExtension:
@@ -50,7 +44,23 @@ d7:
   gherkin:
     filters:
       tags: "@d7&&~@skipped"
+  suites:
+    default:
+      contexts:
+        - Drupal\DrupalExtension\Context\MinkContext
+        - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\MessageContext
+        - IntegratedExperts\BehatScreenshotExtension\Context\ScreenshotContext
+        - FeatureContextD7
 d8:
   gherkin:
     filters:
       tags: "@d8&&~@skipped"
+  suites:
+    default:
+      contexts:
+        - Drupal\DrupalExtension\Context\MinkContext
+        - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\MessageContext
+        - IntegratedExperts\BehatScreenshotExtension\Context\ScreenshotContext
+        - FeatureContextD8

--- a/tests/behat/bootstrap/FeatureContextD7.php
+++ b/tests/behat/bootstrap/FeatureContextD7.php
@@ -7,16 +7,7 @@
 
 use Drupal\DrupalExtension\Context\DrupalContext;
 use IntegratedExperts\BehatSteps\D7\ContentTrait;
-use IntegratedExperts\BehatSteps\D7\DomainTrait;
-use IntegratedExperts\BehatSteps\D7\EmailTrait;
-use IntegratedExperts\BehatSteps\D7\OverrideTrait;
-use IntegratedExperts\BehatSteps\D7\ParagraphsTrait;
 use IntegratedExperts\BehatSteps\D7\UserTrait;
-use IntegratedExperts\BehatSteps\D7\VariableTrait;
-use IntegratedExperts\BehatSteps\D7\WatchdogTrait;
-use IntegratedExperts\BehatSteps\D8\MediaTrait;
-use IntegratedExperts\BehatSteps\DateTrait;
-use IntegratedExperts\BehatSteps\Field;
 use IntegratedExperts\BehatSteps\FieldTrait;
 use IntegratedExperts\BehatSteps\LinkTrait;
 use IntegratedExperts\BehatSteps\PathTrait;
@@ -25,7 +16,7 @@ use IntegratedExperts\BehatSteps\ResponseTrait;
 /**
  * Defines application features from the specific context.
  */
-class FeatureContext extends DrupalContext {
+class FeatureContextD7 extends DrupalContext {
 
   use ContentTrait;
   use FieldTrait;
@@ -39,8 +30,6 @@ class FeatureContext extends DrupalContext {
    */
   public function userDoesNotExist($name) {
     // We need to check that user was removed from both DB and test variables.
-
-    // @todo: Implement support for D8 core driver.
     $user = user_load($name);
 
     if ($user) {

--- a/tests/behat/bootstrap/FeatureContextD8.php
+++ b/tests/behat/bootstrap/FeatureContextD8.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * MYSITE Drupal context for Behat testing.
+ */
+
+use Drupal\DrupalExtension\Context\DrupalContext;
+use IntegratedExperts\BehatSteps\Field;
+use IntegratedExperts\BehatSteps\PathTrait;
+use IntegratedExperts\BehatSteps\ResponseTrait;
+
+/**
+ * Defines application features from the specific context.
+ */
+class FeatureContextD8 extends DrupalContext {
+
+  use PathTrait;
+  use ResponseTrait;
+
+}


### PR DESCRIPTION
This change allows to include only tests for the relevant Drupal version.

Before this PR, including D7 trait into `FeatureContext.php` would break the run for D8 site tests.