### PR TITLE
Use global RuntimeException.

### DIFF
--- a/src/D8/ContentTrait.php
+++ b/src/D8/ContentTrait.php
@@ -35,7 +35,7 @@ trait ContentTrait {
     ]);
 
     if (empty($nids)) {
-      throw new RuntimeException(sprintf('Unable to find %s page "%s"', $type, $title));
+      throw new \RuntimeException(sprintf('Unable to find %s page "%s"', $type, $title));
     }
 
     ksort($nids);
@@ -55,7 +55,7 @@ trait ContentTrait {
     ]);
 
     if (empty($nids)) {
-      throw new RuntimeException(sprintf('Unable to find %s page "%s"', $type, $title));
+      throw new \RuntimeException(sprintf('Unable to find %s page "%s"', $type, $title));
     }
 
     $nid = current($nids);


### PR DESCRIPTION
```
Fatal error: Class 'IntegratedExperts\BehatSteps\D8\RuntimeException' not found (Behat\Testwork\Call\Exception\FatalThrowableError)
```

- Updates the thrown exception to use the global namespace to prevent class not found error.

