### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.6.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
         "drupal/coder": "^8.2.12",
         "drupal/drupal-extension": "^v3.4",
         "integratedexperts/behat-format-progress-fail": "^0.2",
         "integratedexperts/behat-screenshot": "^0.7",
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "wimg/php-compatibility": "^8.1"
+        "phpcompatibility/php-compatibility": "^9.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,7 @@
     <arg value="sp"/>
     <!--Lint code against platform version specified in composer.json
     key "config.platform.php".-->
-    <config name="testVersion" value="7.1"/>
+    <config name="testVersion" value="7.1-"/>
 
     <file>src</file>
 


### PR DESCRIPTION
Composer:
* `wimg/php-compatibility` has been abandoned for nearly a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Use the latest version of the DealerDirect Composer PHPCS plugin.
    Composer treats minors < 1.0 as majors, so you need to explicitly update.

PHPCS ruleset:
* Actually check for cross-version compatibility.
    You were currently just checking if the code was compatible with PHP 7.1 and just and only PHP 7.1, not with _PHP 7.1 and above_. This means that the code is not checked for compatibility with PHP 7.2, 7.3 or even the upcoming 7.4.

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases