### PR TITLE
Added exception handling for delete menus functionality.

### DIFF
--- a/src/D8/MenuTrait.php
+++ b/src/D8/MenuTrait.php
@@ -39,9 +39,11 @@ trait MenuTrait {
    */
   public function menuDelete(TableNode $table) {
     foreach ($table->getColumn(0) as $label) {
-      $menu = $this->loadMenuByLabel($label);
-      if ($menu) {
+      try {
+        $menu = $this->loadMenuByLabel($label);
         $menu->delete();
+      }
+      catch (\Exception $e) {
       }
     }
   }

--- a/tests/behat/features/d8.menu.feature
+++ b/tests/behat/features/d8.menu.feature
@@ -21,8 +21,9 @@ Feature: Check that MenuTrait works for D8
       | [TEST] menu 1 title | Test menu 1 description |
       | [TEST] menu 2 title | Test menu 2 description |
     Given no menus:
-      | [TEST] menu 1 title |
-      | [TEST] menu 2 title |
+      | [TEST] menu 1 title      |
+      | [TEST] menu 2 title      |
+      | [TEST] non-existent menu |
     And I am logged in as a user with the "administrator" role
     When I visit "/admin/structure/menu"
     Then I should not see the text "[TEST] menu 1 title"


### PR DESCRIPTION

### Background
I found an unhandled exception in the `@Given no menus` step, if `MenuTrai::loadMenuByLabel` doesn't find a menu it throws an exception.

In the case of deleting menus we want the step to continue in this case and so I've added exception handling to step through this exception

### What has changed
1. Added no menu exception handling in `@Given no menus` step
2. Added non-existing menu to MenuTrait test to prove the functionality